### PR TITLE
updated model (text-davinci-003 was depreciated)

### DIFF
--- a/configs/openai/openai_completion_example.yaml
+++ b/configs/openai/openai_completion_example.yaml
@@ -5,7 +5,7 @@ batch_size: 20
 
 # API details on "completion" task can be found here: https://platform.openai.com/docs/api-reference/completions
 params:  # Below shows the parameters that are passed to the API call directly
-  model: "text-davinci-003"
+  model: "gpt-3.5-turbo-instruct"
   suffix: null
   max_tokens: 128
   temperature: 1.0


### PR DESCRIPTION
![Screenshot from 2024-04-11 18-22-55](https://github.com/minnesotanlp/talkative-llm/assets/50306883/69488cff-03f8-4229-bb97-d59e6f2d5951)

The OpenAI library wouldn't run with the text-davinci-003 model because it was depreciated. I upgraded it to the newer replacement based on the OpenAI recommendation shown on this [page](https://platform.openai.com/docs/deprecations/2023-07-06-gpt-and-embeddings).